### PR TITLE
Sconsmode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
         - ar -rv libgtest.a gtest-all.o
         - popd
         - cd cpp/src
-      install: scons -j10 -Q mode=travis
+      install: scons -j10 --mode=travis
       script: ./run_tests.sh
     - name: "python integration tests"
       language: python

--- a/cpp/src/SConscript
+++ b/cpp/src/SConscript
@@ -52,10 +52,8 @@ mode = mode_raw if mode_raw is not None else "debug"
 
 #documentation: compile in coverage mode using
 #scons [-j30] --mode=coverage
-#available modes: coverage, debug (default), optimized, travis
+#available modes: coverage, debug (default), optimized
 
-if mode!="travis": #Travis uses or used some old g++ compiler, that did not know this option
-  env.Append(CCFLAGS = '-Wsuggest-override')
 if mode=="debug":
   env.Append(CCFLAGS = '-ggdb')
 if mode=="optimized":

--- a/cpp/src/SConscript
+++ b/cpp/src/SConscript
@@ -38,12 +38,23 @@ env = Environment(
     ]
 )
 
-#documentation: compile in coverage mode using
-#scons [-j30] -Q mode=coverage
-#available modes: coverage, debug (default), optimized
-mode = ARGUMENTS.get('mode', 'debug')
+AddOption('--mode',
+          dest='mode',
+          type='string',
+          nargs=1,
+          default='debug',
+          action='store',
+          metavar='DIR',
+          help='modifies compile flags, possible values: debug (default), optimized, coverage')
 
-if mode!="travis":
+mode_raw = GetOption('mode')
+mode = mode_raw if mode_raw is not None else "debug"
+
+#documentation: compile in coverage mode using
+#scons [-j30] --mode=coverage
+#available modes: coverage, debug (default), optimized, travis
+
+if mode!="travis": #Travis uses or used some old g++ compiler, that did not know this option
   env.Append(CCFLAGS = '-Wsuggest-override')
 if mode=="debug":
   env.Append(CCFLAGS = '-ggdb')

--- a/misc/coverage_script
+++ b/misc/coverage_script
@@ -7,7 +7,7 @@ pushd ../cpp/src
 rm -r ../bin
  
 # Step 2: Re-compile whole project, including tests
-scons -j20 -Q "mode=coverage"
+scons -j20 --mode=coverage
  
 # Step 3: Generate initial coverage information
 lcov --no-external -b . -c -i -d ../bin/ -o .coverage.wtest.base


### PR DESCRIPTION
Updating SConscript:
* --mode option instead of old -Q mode option
* removing travis mode (that disabled -Wsuggest-override) because now travis uses gcc 5.4